### PR TITLE
Modification url github

### DIFF
--- a/notebooks/_config.yml
+++ b/notebooks/_config.yml
@@ -5,7 +5,7 @@ author: Thierry Parmentelat
 logo: ../media/logo.png
 
 repository:
-  url: https://github.com/ue22/web-intro
+  url: https://github.com/ue22-p21/web-intro
   branch: main
   path_to_book: notebooks
 


### PR DESCRIPTION
J'ai l'impression que c'est là qu'on configure le lien présent dans le header du nbhosting. En tous cas, aujourd'hui ce lien pointe vers ue22 (sans -p21) qui a l'air d'être une ancienne version.
Mais je ne sais pas tester ;).